### PR TITLE
An alternative way to introduce requirements

### DIFF
--- a/requirements_1.md
+++ b/requirements_1.md
@@ -3,6 +3,7 @@
 - The "lead time" is the number of days that it takes to make a cake.
 - Cakes are always delivered on the day they're finished. Nobody likes stale cake.
 - Small cakes have a lead time of 2 days.
+- Big cakes have a lead time of 3 days.
 
 ## Examples
 
@@ -13,3 +14,7 @@ The delivery date for a cake is the order date plus the lead time.
 Small cakes have a lead time of 2 days.
 
 - An order for a small cake on a Monday has a delivery date of Wednesday
+
+Big cakes have a lead time of 3 days.
+
+- An order for a big cake, placed on Monday, has a delivery date of Thursday.

--- a/requirements_2.md
+++ b/requirements_2.md
@@ -1,14 +1,16 @@
 ## Requirements
 
-- Big cakes have a lead time of 3 days.
-- If Marco receives a cake order in the morning (ie, before 12pm) he starts on the same day.
+- A cake order received in the morning (ie, before 12pm) starts baking on the same day.
+- Custom frosting adds 2 days extra lead time.
 
 ## Examples
-
-Big cakes have a lead time of 3 days.
-
-- An order for a big cake, placed on Monday afternoon, has a delivery date of Thursday.
 
 If a cake order is received in the morning (ie, before 12pm) then baking starts on the same day.
 
 - An order for a small cake, placed on Monday morning, has a delivery date of Tuesday
+
+Custom frosting adds 2 days extra lead time. You can only frost a baked cake.
+
+- An order for a small cake with custom frosting, received on Monday morning, has a delivery date of Thursday.
+  - Cake is baked Monday-Tuesday
+  - Cake is frosted Wednesday-Thursday

--- a/requirements_3.md
+++ b/requirements_3.md
@@ -1,7 +1,8 @@
 ## Requirements
 
-- Custom frosting adds 2 days extra lead time. You can only frost a baked cake.
+- Marco does the baking, Sandro does the frosting.
 - Marco works from Monday-Friday, and Sandro works from Tuesday-Saturday.
+- You can only frost a baked cake (you may not frost and bake simultaneously)
 
 ## Examples
 


### PR DESCRIPTION
Observations:

* Introducing small cake lead time without big cake lead time naturally leads to suspicion
* The morning requirement and the frosting requirements can force api changes, interesting to introduce them together
* Introducing frosting for the first time when introducing working days leads to an intimidating spike up in complexity, when working days are introduced I think the focus should be on _just_ working days and no other new concepts.
* Clarified in the requirements that Marco bakes while Sandro frosts and also clarified why we say "you can only frost a baked cake"